### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Xun Yang, Clara Leivas
 maintainer=Xun Yang
 sentence=Library used for the Svante workshops
 paragraph=Is intended to be used with the Svante robot produced for Arduino Verkstad in Malmo(Sweden)
-category=Robotics
+category=Other
 url=https://github.com/arduinoverkstad/Svante-Workshop
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category 'Robotics' in library Svante is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.
